### PR TITLE
Add timeout on Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,9 @@ def node3 = ''
 def isFinished = false
 
 pipeline {
+    options {
+        timeout(time: 28, unit: 'HOURS') 
+    }  
     agent none
     stages {
         stage ('Start Test'){


### PR DESCRIPTION
Since a full performance test will take more than 24 hours, I set timeout to 28 hours.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

Fix #44 